### PR TITLE
Add cmake files for dds_server and ros2_server demos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.20)
+project(ros2_dds_service_demo)
+
+# --------------------------------------------------------------------------- #
+# Dependencies.
+
+find_package(microcdr)
+find_package(microxrcedds_client)
+
+# Debug.
+# message("microcdr_FOUND: ${microcdr_FOUND}")
+# message("microcdr_INCLUDE_DIR: ${microcdr_INCLUDE_DIR}")
+# message("microcdr_LIB_DIR: ${microcdr_LIB_DIR}")
+# message("microxrcedds_client_FOUND: ${microxrcedds_client_FOUND}")
+# message("microxrcedds_client_INCLUDE_DIR: ${microxrcedds_client_INCLUDE_DIR}")
+# message("microxrcedds_client_LIB_DIR: ${microxrcedds_client_LIB_DIR}")
+
+# --------------------------------------------------------------------------- #
+# Subdirectories
+
+add_subdirectory(DDS_Server)
+add_subdirectory(ROS2_Server)
+
+# --------------------------------------------------------------------------- #

--- a/DDS_Server/CMakeLists.txt
+++ b/DDS_Server/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.20)
+project(dds_server_demo)
+
+# --------------------------------------------------------------------------- #
+# Dependencies.
+
+find_package(microcdr)
+find_package(microxrcedds_client)
+
+# Debug.
+# message("microcdr_FOUND: ${microcdr_FOUND}")
+# message("microcdr_INCLUDE_DIR: ${microcdr_INCLUDE_DIR}")
+# message("microcdr_LIB_DIR: ${microcdr_LIB_DIR}")
+# message("microxrcedds_client_FOUND: ${microxrcedds_client_FOUND}")
+# message("microxrcedds_client_INCLUDE_DIR: ${microxrcedds_client_INCLUDE_DIR}")
+# message("microxrcedds_client_LIB_DIR: ${microxrcedds_client_LIB_DIR}")
+
+# --------------------------------------------------------------------------- #
+# Build.
+
+add_executable(dds_server_demo Server.c)
+target_include_directories(dds_server_demo
+  PRIVATE
+  ${microcdr_INCLUDE_DIR}
+  ${microxrcedds_client_INCLUDE_DIR}  
+)
+target_link_directories(dds_server_demo
+  PRIVATE
+  ${microcdr_LIB_DIR}
+  ${microxrcedds_client_LIB_DIR}  
+)
+target_link_libraries(dds_server_demo
+  microcdr
+  microxrcedds_client
+)
+
+# --------------------------------------------------------------------------- #
+#  Install.
+
+install(TARGETS
+  dds_server_demo
+  RUNTIME DESTINATION bin/
+)
+
+install(FILES
+  fastdds_server__addtwoints.yaml
+  DESTINATION share/${PROJECT_NAME}/config
+)
+
+# --------------------------------------------------------------------------- #

--- a/DDS_Server/CMakeLists.txt
+++ b/DDS_Server/CMakeLists.txt
@@ -1,20 +1,3 @@
-cmake_minimum_required(VERSION 3.20)
-project(dds_server_demo)
-
-# --------------------------------------------------------------------------- #
-# Dependencies.
-
-find_package(microcdr)
-find_package(microxrcedds_client)
-
-# Debug.
-# message("microcdr_FOUND: ${microcdr_FOUND}")
-# message("microcdr_INCLUDE_DIR: ${microcdr_INCLUDE_DIR}")
-# message("microcdr_LIB_DIR: ${microcdr_LIB_DIR}")
-# message("microxrcedds_client_FOUND: ${microxrcedds_client_FOUND}")
-# message("microxrcedds_client_INCLUDE_DIR: ${microxrcedds_client_INCLUDE_DIR}")
-# message("microxrcedds_client_LIB_DIR: ${microxrcedds_client_LIB_DIR}")
-
 # --------------------------------------------------------------------------- #
 # Build.
 

--- a/ROS2_Server/CMakeLists.txt
+++ b/ROS2_Server/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.20)
+project(ros2_server_demo)
+
+# --------------------------------------------------------------------------- #
+# Dependencies.
+
+find_package(microcdr)
+find_package(microxrcedds_client)
+
+# --------------------------------------------------------------------------- #
+# Build.
+
+add_executable(ros2_server_demo Client.c)
+target_include_directories(ros2_server_demo
+  PRIVATE
+  ${microcdr_INCLUDE_DIR}
+  ${microxrcedds_client_INCLUDE_DIR}  
+)
+target_link_directories(ros2_server_demo
+  PRIVATE
+  ${microcdr_LIB_DIR}
+  ${microxrcedds_client_LIB_DIR}  
+)
+target_link_libraries(ros2_server_demo
+  microcdr
+  microxrcedds_client
+)
+
+# --------------------------------------------------------------------------- #
+#  Install.
+
+install(TARGETS
+  ros2_server_demo
+  RUNTIME DESTINATION bin/
+)
+
+install(FILES
+  ros2_server__addtwoints.yaml
+  DESTINATION share/${PROJECT_NAME}/config
+)
+
+# --------------------------------------------------------------------------- #

--- a/ROS2_Server/CMakeLists.txt
+++ b/ROS2_Server/CMakeLists.txt
@@ -1,12 +1,3 @@
-cmake_minimum_required(VERSION 3.20)
-project(ros2_server_demo)
-
-# --------------------------------------------------------------------------- #
-# Dependencies.
-
-find_package(microcdr)
-find_package(microxrcedds_client)
-
 # --------------------------------------------------------------------------- #
 # Build.
 


### PR DESCRIPTION
Add CMakeLists.txt for the DDS and ROS 2 server demos.

Build in `colcon` with:

```bash
colcon build --symlink-install --merge-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-select dds_server_demo ros2_server_demo
```

The binaries are installed to

```bash
~/dds_ws/install/bin
```

and the config files to

```bash
~/dds_ws/install/share/dds_server_demo/config/fastdds_server__addtwoints.yaml
~/dds_ws/install/share/ros2_server_demo/config/ros2_server__addtwoints.yaml
```
